### PR TITLE
Fix updater for fal images

### DIFF
--- a/Classes/Update/migrateImagesToFal.php
+++ b/Classes/Update/migrateImagesToFal.php
@@ -144,7 +144,7 @@ You have been warned ;-)';
                 LEFT JOIN sys_file_reference r 
                     ON r.uid_foreign = n.uid AND r.tablenames = \'tt_news\' AND r.fieldname = \'image\' AND r.deleted = 0
                 
-                WHERE n.image != \'\'
+                WHERE NOT(image > 0) AND image <> "" AND image <> "0"
                   AND n.deleted = 0
                   AND r.uid IS NULL
                  '
@@ -245,7 +245,7 @@ You have been warned ;-)';
                 LEFT JOIN sys_file_reference r 
                     ON r.uid_foreign = n.uid AND r.tablenames = \'tt_news\' AND r.fieldname = \'image\' AND r.deleted = 0
                 
-                WHERE n.image != \'\'
+                WHERE NOT(image > 0) AND image <> "" AND image <> "0"
                   AND n.deleted = 0
                   AND r.uid IS NULL
                  '


### PR DESCRIPTION
My updater stopped prematurely and thus I had records were image was either pre-upgrade (e.g. <filename> or <emptystring>) and some were int. From this I couldn't re-run the wizard.

This change takes this into account.