### PR TITLE
[BUGFIX] pages type icon definition should be in TCA folder

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -3,3 +3,6 @@
 defined('TYPO3') or die();
 // Register typeicon (the icon itself is registered in ext_tables.php)
 $GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['contains-news'] = 'tcarecords-pages-contains-news';
+// add folder icon
+$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['contains-tt_news'] = 'apps-pagetree-folder-contains-news';
+$GLOBALS['TCA']['pages']['columns']['module']['config']['items'][] = [0 => 'LLL:EXT:tt_news/Resources/Private/Language/locallang_tca.xlf:tt_news', 1 => 'tt_news', 2 => 'apps-pagetree-folder-contains-news'];

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -99,10 +99,6 @@ $boot = function () {
             BitmapIconProvider::class,
             ['source' => 'EXT:tt_news/Resources/Public/Images/Icons/tt_news_exturl.gif']
         );
-
-        // add folder icon
-        $GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['contains-tt_news'] = 'apps-pagetree-folder-contains-news';
-        $GLOBALS['TCA']['pages']['columns']['module']['config']['items'][] = [0 => 'LLL:EXT:tt_news/Resources/Private/Language/locallang_tca.xlf:tt_news', 1 => 'tt_news', 2 => 'apps-pagetree-folder-contains-news'];
     }
 };
 


### PR DESCRIPTION
In order for easier override and for the sake of standards